### PR TITLE
(engine): Assign the first trick's lead player when bidding is complete

### DIFF
--- a/typescript/src/match.ts
+++ b/typescript/src/match.ts
@@ -118,7 +118,10 @@ export class Match {
             console.log(`Bid of ${bid} from ${playerName} is not valid.`);
             return false
         };
+    }
 
+    completeBidding() {
+        this.trick.leadPlayer = this.round.bid.playerName
     }
 
     playCard(playerName: string, cardName: string): void {

--- a/typescript/tests/scenarios.ts
+++ b/typescript/tests/scenarios.ts
@@ -53,9 +53,10 @@ test(`walk through initial setup and one complete round`, t => {
     match.makeBid('KG', 2);
     match.makeBid('KP', 3);
     t.deepEqual(match.round.bid, {playerName: 'KP', amount: 3});
+    // Complete the bidding
+    match.completeBidding()
+    t.is(match.trick.leadPlayer, 'KP')
     // Play the first trick's cards
-    // TODO - Add a completeBids() function that assigns trick.leadPlayer
-    // t.is(match.trick.leadPlayer, 'KP')
     match.playCard('KP', 'ace of hearts');
     t.is(match.trick.leadSuit, 'hearts');
     t.is(match.round.trumpSuit, 'hearts');


### PR DESCRIPTION
After all bids are completed, call a `completeBidding` function that will assign `trick.leadPlayer` to the player with the winning bid.